### PR TITLE
Initialize all debate state fields to prevent KeyErrors

### DIFF
--- a/tradingagents/graph/propagation.py
+++ b/tradingagents/graph/propagation.py
@@ -23,15 +23,29 @@ class Propagator:
             "messages": [("human", company_name)],
             "company_of_interest": company_name,
             "trade_date": str(trade_date),
+            # Pre-populate debate state dictionaries with all required keys so
+            # downstream logic that reads from them doesn't encounter KeyError
             "investment_debate_state": InvestDebateState(
-                {"history": "", "current_response": "", "count": 0}
+                {
+                    "history": "",
+                    "bull_history": "",
+                    "bear_history": "",
+                    "current_response": "",
+                    "judge_decision": "",
+                    "count": 0,
+                }
             ),
             "risk_debate_state": RiskDebateState(
                 {
                     "history": "",
+                    "risky_history": "",
+                    "safe_history": "",
+                    "neutral_history": "",
+                    "latest_speaker": "",
                     "current_risky_response": "",
                     "current_safe_response": "",
                     "current_neutral_response": "",
+                    "judge_decision": "",
                     "count": 0,
                 }
             ),


### PR DESCRIPTION
## Summary
- populate investment and risk debate states with all required fields during initial state creation so later components don't encounter missing keys

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aaed027a6083209e1d1fa1afaee0e8