### PR TITLE
Fix Markdown typo in news analyst prompt

### DIFF
--- a/tradingagents/agents/analysts/news_analyst.py
+++ b/tradingagents/agents/analysts/news_analyst.py
@@ -1,6 +1,4 @@
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-import time
-import json
 
 
 def create_news_analyst(llm, toolkit):
@@ -19,7 +17,7 @@ def create_news_analyst(llm, toolkit):
 
         system_message = (
             "You are a news researcher tasked with analyzing recent news and trends over the past week. Please write a comprehensive report of the current state of the world that is relevant for trading and macroeconomics. Look at news from EODHD, and finnhub to be comprehensive. Do not simply state the trends are mixed, provide detailed and finegrained analysis and insights that may help traders make decisions."
-            + """ Make sure to append a Makrdown table at the end of the report to organize key points in the report, organized and easy to read."""
+            + """ Make sure to append a Markdown table at the end of the report to organize key points in the report, organized and easy to read."""
         )
 
         prompt = ChatPromptTemplate.from_messages(


### PR DESCRIPTION
## Summary
- Correct a typo in the news analyst prompt: "Makrdown" -> "Markdown".
- Clean up unused imports flagged by static analysis.

## Testing
- `ruff check tradingagents/agents/analysts/news_analyst.py`


------
https://chatgpt.com/codex/tasks/task_b_68aaee5958a08320b90b8455d9d70dd2