### PR TITLE
docs: clarify finnhub news parameters

### DIFF
--- a/tradingagents/dataflows/interface.py
+++ b/tradingagents/dataflows/interface.py
@@ -27,12 +27,13 @@ def get_finnhub_news(
     """
     Retrieve news about a company within a time frame
 
-    Args
-        ticker (str): ticker for the company you are interested in
-        start_date (str): Start date in yyyy-mm-dd format
-        end_date (str): End date in yyyy-mm-dd format
-    Returns
-        str: dataframe containing the news of the company in the time frame
+    Args:
+        ticker (str): ticker symbol for the company
+        curr_date (str): current date in yyyy-mm-dd format
+        look_back_days (int): number of days to look back from curr_date
+
+    Returns:
+        str: formatted string summarizing the company's news in the time frame
 
     """
 


### PR DESCRIPTION
## Summary
- detail ticker, date, and lookback parameters for `get_finnhub_news`
- note function returns a formatted summary string

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aaee7419c08320993465d3adc266eb