### PR TITLE
Make LLM config use environment variables

### DIFF
--- a/tradingagents/default_config.py
+++ b/tradingagents/default_config.py
@@ -9,10 +9,17 @@ DEFAULT_CONFIG = {
         "dataflows/data_cache",
     ),
     # LLM settings
-    "llm_provider": "openai",
-    "deep_think_llm": "o4-mini",
-    "quick_think_llm": "gpt-4o-mini",
-    "backend_url": "https://api.openai.com/v1",
+    # These can be overridden with environment variables
+    # TRADINGAGENTS_LLM_PROVIDER, TRADINGAGENTS_BACKEND_URL,
+    # TRADINGAGENTS_DEEP_THINK_LLM, and TRADINGAGENTS_QUICK_THINK_LLM
+    "llm_provider": os.getenv("TRADINGAGENTS_LLM_PROVIDER", "openrouter"),
+    "deep_think_llm": os.getenv(
+        "TRADINGAGENTS_DEEP_THINK_LLM", "mistralai/mixtral-8x7b-instruct"
+    ),
+    "quick_think_llm": os.getenv(
+        "TRADINGAGENTS_QUICK_THINK_LLM", "mistralai/mistral-7b-instruct"
+    ),
+    "backend_url": os.getenv("TRADINGAGENTS_BACKEND_URL", "https://openrouter.ai/api/v1"),
     # Debate and discussion settings
     "max_debate_rounds": 1,
     "max_risk_discuss_rounds": 1,


### PR DESCRIPTION
## Summary
- Allow overriding LLM provider, backend URL, and model names with environment variables
- Default configuration points to OpenRouter with free models

## Testing
- `python -m pytest`
- `python -m py_compile tradingagents/default_config.py`


------
https://chatgpt.com/codex/tasks/task_b_68aaee9d53a48320ac1870eba6df5e57