### PR TITLE
Add optional extras for local model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Install dependencies:
 pip install -r requirements.txt
 ```
 
+Install with optional dependencies for local `transformers` or `llama-cpp-python` support:
+```bash
+pip install tradingagents[local]
+```
+
 ### Required APIs
 
 You will also need the FinnHub API for financial data. All of our code is implemented with the free tier.

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,7 @@ rich
 questionary
 langchain_anthropic
 langchain-google-genai
+
+# Optional dependencies for running local models
+transformers; extra == "local"
+llama-cpp-python; extra == "local"

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,12 @@ setup(
         "rich>=13.0.0",
         "questionary>=2.0.1",
     ],
+    extras_require={
+        "local": [
+            "transformers",
+            "llama-cpp-python",
+        ],
+    },
     python_requires=">=3.10",
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
- add optional `local` extra requiring transformers and llama-cpp-python
- document installation of optional extras in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68aaeea02f188320a13896aef4a3dfa9